### PR TITLE
Fix deprecated commands

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     - name: Set up PATH
-      run: | 
+      run: |
         echo "${ANDROID_HOME}/build-tools/30.0.1" >> $GITHUB_PATH
         echo "REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')" >> $GITHUB_ENV
     - name: Set up JDK 14

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,11 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+    - name: Install Android SDK
+      uses: android-actions/setup-android@v2.0.1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     - name: Set up PATH
-      run: |
-        echo "::add-path::${ANDROID_HOME}/build-tools/30.0.1"
-        echo ::set-env name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')
+      run: | 
+        echo "${ANDROID_HOME}/build-tools/30.0.1" >> $GITHUB_PATH
+        echo "REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')" >> $GITHUB_ENV
     - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories{
 
 ext{
     //the build number that this mod is made for
-    mindustryVersion = 'v106'
+    mindustryVersion = 'v116'
     //version of SDK you will be using
     sdkVersion = '30'
     sdkRoot = System.getenv("ANDROID_HOME")


### PR DESCRIPTION
Fixed deprecated GitHub actions commands ([this](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)) and updated build version to v116.